### PR TITLE
Add show command and refactor init

### DIFF
--- a/Cognite.Jetfire.Cli/Cognite.Jetfire.Cli.csproj
+++ b/Cognite.Jetfire.Cli/Cognite.Jetfire.Cli.csproj
@@ -18,5 +18,6 @@
 
   <ItemGroup>
     <Folder Include="ListTransforms\" />
+    <Folder Include="Show\" />
   </ItemGroup>
 </Project>

--- a/Cognite.Jetfire.Cli/Deploy/DeployCommand.cs
+++ b/Cognite.Jetfire.Cli/Deploy/DeployCommand.cs
@@ -16,7 +16,7 @@ using Cognite.Jetfire.Cli.Deploy.Manifest;
 
 namespace Cognite.Jetfire.Cli.Deploy
 {
-    public class DeployCommand
+    public class DeployCommand : IJetfireSubCommand
     {
         public DeployCommand(ISecretsProvider secrets)
         {

--- a/Cognite.Jetfire.Cli/IJetfireSubCommand.cs
+++ b/Cognite.Jetfire.Cli/IJetfireSubCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using System.CommandLine;
+
+namespace Cognite.Jetfire.Cli
+{
+    public interface IJetfireSubCommand
+    {
+        Command Command { get; }
+    }
+}

--- a/Cognite.Jetfire.Cli/JetfireRootCommand.cs
+++ b/Cognite.Jetfire.Cli/JetfireRootCommand.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,12 +12,7 @@ namespace Cognite.Jetfire.Cli
 {
     public class JetfireRootCommand
     {
-        public JetfireRootCommand(
-            Deploy.DeployCommand deployCommand,
-            Query.QueryCommand queryCommand,
-            Run.RunCommand runCommand,
-            ListTransforms.ListCommand listCommand
-        )
+        public JetfireRootCommand(IList<IJetfireSubCommand> subCommands)
         {
             Command = new RootCommand
             {
@@ -23,12 +20,13 @@ namespace Cognite.Jetfire.Cli
                     alias: "--cluster",
                     description: "The CDF cluster where Jetfire is hosted (e.g. greenfield, europe-west1-1)",
                     getDefaultValue: () => "europe-west1-1"
-                ),
-                deployCommand.Command,
-                queryCommand.Command,
-                runCommand.Command,
-                listCommand.Command,
+                )
             };
+
+            foreach (var subCommand in subCommands)
+            {
+                Command.Add(subCommand.Command);
+            }
         }
 
         public RootCommand Command { get; }

--- a/Cognite.Jetfire.Cli/ListTransforms/ListCommand.cs
+++ b/Cognite.Jetfire.Cli/ListTransforms/ListCommand.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Cognite.Jetfire.Cli.ListTransforms
 {
-    public class ListCommand
+    public class ListCommand : IJetfireSubCommand
     {
         public Command Command { get; }
         private ISecretsProvider Secrets;

--- a/Cognite.Jetfire.Cli/Program.cs
+++ b/Cognite.Jetfire.Cli/Program.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.Threading.Tasks;
 using Cognite.Jetfire.Cli.Deploy;
 using Cognite.Jetfire.Cli.ListTransforms;
 using Cognite.Jetfire.Cli.Query;
 using Cognite.Jetfire.Cli.Run;
+using Cognite.Jetfire.Cli.Show;
 
 namespace Cognite.Jetfire.Cli
 {
@@ -18,10 +20,13 @@ namespace Cognite.Jetfire.Cli
             var secrets = new EnvironmentSecretsProvider();
 
             var rootCommand = new JetfireRootCommand(
-                new DeployCommand(secrets),
-                new QueryCommand(secrets),
-                new RunCommand(secrets),
-                new ListCommand(secrets)
+                new List<IJetfireSubCommand>() {
+                    new DeployCommand(secrets),
+                    new QueryCommand(secrets),
+                    new RunCommand(secrets),
+                    new ListCommand(secrets),
+                    new ShowCommand(secrets)
+                }
             );
 
             return await rootCommand.Command.InvokeAsync(args);

--- a/Cognite.Jetfire.Cli/Query/QueryCommand.cs
+++ b/Cognite.Jetfire.Cli/Query/QueryCommand.cs
@@ -13,7 +13,7 @@ using Cognite.Jetfire.Api.Model;
 
 namespace Cognite.Jetfire.Cli.Query
 {
-    public class QueryCommand
+    public class QueryCommand : IJetfireSubCommand
     {
         public Command Command { get; }
 

--- a/Cognite.Jetfire.Cli/Run/RunCommand.cs
+++ b/Cognite.Jetfire.Cli/Run/RunCommand.cs
@@ -18,7 +18,7 @@ using System.CommandLine.Binding;
 
 namespace Cognite.Jetfire.Cli.Run
 {
-    public class RunCommand
+    public class RunCommand : IJetfireSubCommand
     {
         public RunCommand(ISecretsProvider secrets)
         {

--- a/Cognite.Jetfire.Cli/Show/ShowCommand.cs
+++ b/Cognite.Jetfire.Cli/Show/ShowCommand.cs
@@ -1,0 +1,79 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+using Cognite.Jetfire.Api.Model;
+
+namespace Cognite.Jetfire.Cli.Show
+{
+    public class ShowCommand : IJetfireSubCommand
+    {
+        public Command Command { get; }
+        private ISecretsProvider Secrets;
+
+        public ShowCommand(ISecretsProvider secrets)
+        {
+            Secrets = secrets;
+
+            Command = new Command("show", "Show detalis of a transformation")
+            {
+                new Option<int?>("--id")
+                {
+                    Description = "The id of the transformation to show. Either this or --external-id must be specified."
+                },
+                new Option<string>("--external-id")
+                {
+                    Description = "The externalId of the transformation to show. Either this or --id must be specified."
+                }
+            };
+
+            Command.Handler = CommandHandler.Create<string, int?, string>(Handle);
+
+        }
+
+        async Task Handle(string cluster, int? id, string externalId)
+        {
+            TransformConfigRead transform;
+
+            using (var client = JetfireClientFactory.CreateClient(Secrets, cluster))
+            {
+
+                if (id == null && externalId != null)
+                {
+                    transform = await client.TransformConfigByExternalId(externalId, new CancellationToken());
+                }
+                else if (id != null && externalId == null)
+                {
+                    transform = await client.TransformConfigById(id.Value, new CancellationToken());
+                }
+                else
+                {
+                    throw new Exception("Either --id or --external-id must be specified");
+                }
+            }
+
+            Console.WriteLine($"Name:           {transform.Name}");
+            Console.WriteLine($"ID:             {transform.Id}");
+            Console.WriteLine($"External ID:    {transform.ExternalId}");
+
+            Console.WriteLine();
+
+            Console.WriteLine($"Destination:    {transform.Destination.Type}");
+            if (transform.Destination.Type == "raw_table")
+            {
+                Console.WriteLine($"   Database:    {transform.Destination.Database}");
+                Console.WriteLine($"   Table:       {transform.Destination.Table}");
+                Console.WriteLine($"   Raw type:    {transform.Destination.RawType}");
+            }
+            Console.WriteLine($"Action:         {transform.ConflictMode}");
+            Console.WriteLine($"Schedule:       {transform?.Schedule?.ToString()?.ToLower() ?? "no schedule"}");
+
+            Console.WriteLine();
+            Console.WriteLine("".PadLeft(50, '-'));
+            Console.WriteLine();
+
+            Console.WriteLine(transform.Query);
+        }
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,22 @@
+coverage:
+  precision: 2
+  round: down
+  range: "40...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 100%
+        base: auto
+    patch: off
+    changes: off
+
+comment:
+  layout: "header, diff, files"
+  behavior: default
+
 codecov:
-  require_ci_to_pass: no
-  branch: v1
+  notify:
+    require_ci_to_pass: false
+    after_n_builds: 1  # send notifications and complete cc build after 1 upload

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  require_ci_to_pass: no
+  branch: v1


### PR DESCRIPTION
Add a `show` command that displays details about a transform not shown
in the `list` command.

Add an `IJetfireSubCommand` interface, and take a list of these in the
`JetfireRootCommand` class instead of an explicit list of all the
commands. Should make extending further easier as there are fewer
places to add the new command.