### PR TITLE
Add custom error handling

### DIFF
--- a/Cognite.Jetfire.Cli/Delete/DeleteCommand.cs
+++ b/Cognite.Jetfire.Cli/Delete/DeleteCommand.cs
@@ -35,7 +35,7 @@ namespace Cognite.Jetfire.Cli.Delete
             if (id == null && externalId == null ||
                 id != null && externalId != null)
             {
-                throw new Exception("Either --id or --external-id must be specified");
+                throw new JetfireCliException("Either --id or --external-id must be specified");
             }
 
             using (var client = JetfireClientFactory.CreateClient(secrets, cluster))

--- a/Cognite.Jetfire.Cli/JetfireCliException.cs
+++ b/Cognite.Jetfire.Cli/JetfireCliException.cs
@@ -1,0 +1,9 @@
+using System;
+namespace Cognite.Jetfire.Cli
+{
+    public class JetfireCliException : Exception
+    {
+        public JetfireCliException(string message) : base(message)
+        { }
+    }
+}

--- a/Cognite.Jetfire.Cli/JetfireClientFactory.cs
+++ b/Cognite.Jetfire.Cli/JetfireClientFactory.cs
@@ -22,7 +22,7 @@ namespace Cognite.Jetfire.Cli
             var apiKey = secrets.GetNamedSecret(ApiKeyEnvironmentVariable);
             if (string.IsNullOrWhiteSpace(apiKey))
             {
-                throw new Exception($"The {ApiKeyEnvironmentVariable} environment variable must be set");
+                throw new JetfireCliException($"The {ApiKeyEnvironmentVariable} environment variable must be set");
             }
             return new ApiKeyCredentials(apiKey);
         }

--- a/Cognite.Jetfire.Cli/JetfireRootCommand.cs
+++ b/Cognite.Jetfire.Cli/JetfireRootCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Builder;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,18 @@ namespace Cognite.Jetfire.Cli
             {
                 Command.Add(subCommand.Command);
             }
+
+            var _ = new CommandLineBuilder(Command)
+               .UseVersionOption()
+               .UseHelp()
+               .UseParseDirective()
+               .UseDebugDirective()
+               .UseSuggestDirective()
+               .RegisterWithDotnetSuggest()
+               .UseTypoCorrections()
+               .UseParseErrorReporting()
+               .CancelOnProcessTermination()
+               .Build();
         }
 
         public RootCommand Command { get; }

--- a/Cognite.Jetfire.Cli/Program.cs
+++ b/Cognite.Jetfire.Cli/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.Threading.Tasks;
+using Cognite.Jetfire.Api;
 using Cognite.Jetfire.Cli.Delete;
 using Cognite.Jetfire.Cli.Deploy;
 using Cognite.Jetfire.Cli.ListTransforms;
@@ -31,7 +32,26 @@ namespace Cognite.Jetfire.Cli
                 }
             );
 
-            return await rootCommand.Command.InvokeAsync(args);
+            try
+            {
+                return await rootCommand.Command.InvokeAsync(args);
+            }
+            catch (JetfireCliException e)
+            {
+                Console.Error.WriteLine($"Error: {e.Message}");
+                return 1;
+            }
+            catch (JetfireApiException e)
+            {
+                Console.Error.WriteLine($"API Error: {e.Message}");
+                return 1;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"Unhandled error: {e.Message}");
+                Console.Error.WriteLine(e.StackTrace);
+                return 1;
+            }
         }
     }
 }

--- a/Cognite.Jetfire.Cli/Run/RunCommand.cs
+++ b/Cognite.Jetfire.Cli/Run/RunCommand.cs
@@ -78,7 +78,7 @@ namespace Cognite.Jetfire.Cli.Run
             if (id == null && externalId == null ||
                 id != null && externalId != null)
             {
-                throw new Exception("Either --id or --external-id must be specified");
+                throw new JetfireCliException("Either --id or --external-id must be specified");
             }
 
             int configId;
@@ -174,7 +174,7 @@ namespace Cognite.Jetfire.Cli.Run
         }
     }
 
-    public class JobStatusException : Exception
+    public class JobStatusException : JetfireCliException
     {
         public TransformJob Job { get; }
 

--- a/Cognite.Jetfire.Cli/Show/ShowCommand.cs
+++ b/Cognite.Jetfire.Cli/Show/ShowCommand.cs
@@ -49,7 +49,7 @@ namespace Cognite.Jetfire.Cli.Show
                 }
                 else
                 {
-                    throw new Exception("Either --id or --external-id must be specified");
+                    throw new JetfireCliException("Either --id or --external-id must be specified");
                 }
             }
 


### PR DESCRIPTION
The default error handling in comandline is a bit lacking:

 * It dumps the entire stack trace in the terminal every time, which is
   not great UX (especially when we use exceptions for error messages)
 * Unhandled exceptions caused a couple of problems with dotnet core
   on Mac OS, causing dotnet to crash.

Add a JetfireCliException class (in addition to JetfireApiException),
and treat these separately, only printing a simple error message when
possible.