### PR TITLE
[CDF-10158] Don't change publish state if it hasn't changed

### DIFF
--- a/Cognite.Jetfire.Api/Model/TransformConfig.cs
+++ b/Cognite.Jetfire.Api/Model/TransformConfig.cs
@@ -22,6 +22,8 @@ namespace Cognite.Jetfire.Api.Model
         public string ConflictMode { get; set; }
 
         public ScheduleParams Schedule { get; set; }
+
+        public bool IsPublic { get; set; }
     }
 
     public class TransformConfigCreate

--- a/Cognite.Jetfire.Cli/Deploy/Deployment.cs
+++ b/Cognite.Jetfire.Cli/Deploy/Deployment.cs
@@ -50,7 +50,7 @@ namespace Cognite.Jetfire.Cli.Deploy
             {
                 transformId = existingTransformToUpdate.Id;
                 console.Out.WriteLine($"Transformation '{externalId}' already exists, updating...");
-                await Update(existingTransformToUpdate.Id, resolvedManifest);
+                await Update(existingTransformToUpdate, resolvedManifest);
             }
 
             console.Out.WriteLine($"Updating schedule for transformation '{externalId}'");
@@ -75,8 +75,9 @@ namespace Cognite.Jetfire.Cli.Deploy
             });
         }
 
-        async Task Update(int id, ResolvedManifest manifest)
+        async Task Update(TransformConfigRead transformToUpdate, ResolvedManifest manifest)
         {
+            var id = transformToUpdate.Id;
             await client.TransformConfigUpdate(id, new TransformConfigUpdate
             {
                 Name = manifest.Transformation.Name,
@@ -87,7 +88,11 @@ namespace Cognite.Jetfire.Cli.Deploy
 
             await client.TransformConfigUpdateSourceApiKey(id, manifest.ReadApiKey);
             await client.TransformConfigUpdateDestinationApiKey(id, manifest.WriteApiKey);
-            await client.TransformConfigSetPublished(id, manifest.Transformation.Shared);
+
+            if (transformToUpdate.IsPublic != manifest.Transformation.Shared)
+            {
+                await client.TransformConfigSetPublished(id, manifest.Transformation.Shared);
+            }
         }
 
         async Task UpdateSchedule(int id, ResolvedManifest manifest)


### PR DESCRIPTION
This would cause an error when attempting to update a transformation that was created by another service account, as only the owner of the transformation is allowed to publish/unpublish it.