### PR TITLE
Ignore all < 500 errors on try schedule delete

### DIFF
--- a/Cognite.Jetfire.Cli/Deploy/Deployment.cs
+++ b/Cognite.Jetfire.Cli/Deploy/Deployment.cs
@@ -79,7 +79,7 @@ namespace Cognite.Jetfire.Cli.Deploy
                 DestinationApiKey = manifest.WriteApiKey,
                 SourceOidcCredentials = manifest.ReadCredentials,
                 DestinationOidcCredentials = manifest.WriteCredentials
-            }); ;
+            });
         }
 
         async Task Update(TransformConfigRead transformToUpdate, ResolvedManifest manifest)
@@ -122,7 +122,7 @@ namespace Cognite.Jetfire.Cli.Deploy
                     await client.ScheduleDelete(id);
                 }
                 catch (JetfireApiException e)
-                when (e.StatusCode == HttpStatusCode.NotFound)
+                when ((int)e.StatusCode < 500)
                 { }
             }
             else


### PR DESCRIPTION
The refactored backend serves 400 errors when schedules are
non-exsistent, compared to the old version which returned 404s