### PR TITLE
Do not use rawType in deploy but be able to parse it

### DIFF
--- a/Cognite.Jetfire.Api/Model/TransformConfig.cs
+++ b/Cognite.Jetfire.Api/Model/TransformConfig.cs
@@ -120,6 +120,15 @@ namespace Cognite.Jetfire.Api.Model
             };
         }
 
+        public static DataSource NewRaw(string database, string table)
+        {
+            return new DataSource("raw")
+            {
+                Database = database,
+                Table = table
+            };
+        }
+
         public string RawType { get; set; }
 
         public string Database { get; set; }

--- a/Cognite.Jetfire.Cli/Deploy/Deployment.cs
+++ b/Cognite.Jetfire.Cli/Deploy/Deployment.cs
@@ -195,7 +195,7 @@ namespace Cognite.Jetfire.Cli.Deploy
 
         static DataSource ToRawTableDataSource(Destination destination)
         {
-            return DataSource.Raw(
+            return DataSource.NewRaw(
                 database: destination.RawDatabase,
                 table: destination.RawTable
             );

--- a/Cognite.Jetfire.Cli/Show/ShowCommand.cs
+++ b/Cognite.Jetfire.Cli/Show/ShowCommand.cs
@@ -83,11 +83,10 @@ namespace Cognite.Jetfire.Cli.Show
             Console.WriteLine();
 
             Console.WriteLine($"Destination:    {transform.Destination.Type}");
-            if (transform.Destination.Type == "raw_table")
+            if (transform.Destination.Type == "raw_table" || transform.Destination.Type == "raw")
             {
                 Console.WriteLine($"   Database:    {transform.Destination.Database}");
                 Console.WriteLine($"   Table:       {transform.Destination.Table}");
-                Console.WriteLine($"   Raw type:    {transform.Destination.RawType}");
             }
             Console.WriteLine($"Action:         {transform.ConflictMode}");
             Console.WriteLine($"Schedule:       {transform?.Schedule?.ToString()?.ToLower() ?? "no schedule"}");

--- a/Cognite.Jetfire.Cli/Show/ShowCommand.cs
+++ b/Cognite.Jetfire.Cli/Show/ShowCommand.cs
@@ -125,7 +125,7 @@ namespace Cognite.Jetfire.Cli.Show
                 Console.WriteLine();
 
                 Console.WriteLine($"Destination:         {job.DestinationType}");
-                if (job.DestinationType == "raw_table")
+                if (job.DestinationType == "raw_table" || job.DestinationType == "raw")
                 {
                     Console.WriteLine($"   Database:        {job.DestinationDatabase}");
                     Console.WriteLine($"   Table:           {job.DestinationTable}");


### PR DESCRIPTION
Trying to deprecate raw type meaning:
`{"type": "raw_table", "rawType": "plain_raw", "database": "asd", "table":"asd"}
`to
`{"type": "raw", "database": "asd", "table":"asd"}`
we need to support reading the first version until we completely get rid of it. trying to do it in steps.
1- UI will be able to read old+new style, but it will write in old style (until cli supports new version)
2- support new version in CLI: Read both versions but write in new style <----- we are here.
3- UI will deploy using the new style
4- update all entries in jetfire-backend db: raw_table.plain_raw -> raw
5- remove support for old style 

Hope i am not making this more complicated than it needs to be :D 